### PR TITLE
Skip reminder for logged in User

### DIFF
--- a/app/src/main/java/org/commcare/dalvik/reminders/CommCareReceiver.kt
+++ b/app/src/main/java/org/commcare/dalvik/reminders/CommCareReceiver.kt
@@ -3,14 +3,24 @@ package org.commcare.dalvik.reminders;
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
 import org.commcare.dalvik.reminders.sync.SyncCasesWorker
 
 class CommCareReceiver : BroadcastReceiver() {
 
+    companion object {
+        const val CC_LOGGED_IN_USER_ID_KEY = "cc-logged-in-user-id"
+    }
     override fun onReceive(context: Context, intent: Intent) {
-        WorkManager.getInstance(context).enqueue(
-        OneTimeWorkRequest.from(SyncCasesWorker::class.java))
+        val data = Data.Builder()
+        if (intent.hasExtra(CC_LOGGED_IN_USER_ID_KEY)){
+            data.putString(CC_LOGGED_IN_USER_ID_KEY, intent.getStringExtra(CC_LOGGED_IN_USER_ID_KEY))
+        }
+        val syncCasesWorkerRequest = OneTimeWorkRequest.Builder(SyncCasesWorker::class.java)
+            .setInputData(data.build()).build()
+
+        WorkManager.getInstance(context).enqueue(syncCasesWorkerRequest);
     }
 }

--- a/app/src/main/java/org/commcare/dalvik/reminders/db/ReminderRepository.kt
+++ b/app/src/main/java/org/commcare/dalvik/reminders/db/ReminderRepository.kt
@@ -11,8 +11,8 @@ class ReminderRepository(private val reminderDao: ReminderDao) {
 
     val observeReminders: LiveData<List<Reminder>> = reminderDao.observeReminders()
 
-    suspend fun refreshCasesFromCC(context: Context) {
-        CommCareUtils.getRemindersFromCommCare(context).let { reminders ->
+    suspend fun refreshCasesFromCC(context: Context, currentUserId: String?) {
+        CommCareUtils.getRemindersFromCommCare(context, currentUserId).let { reminders ->
             val oldReminders = getAllReminders()
             reminderDao.updateAllReminders(reminders)
             PrefsUtil.markSuccessfulSync(context)

--- a/app/src/main/java/org/commcare/dalvik/reminders/sync/CommCareUtils.kt
+++ b/app/src/main/java/org/commcare/dalvik/reminders/sync/CommCareUtils.kt
@@ -1,6 +1,8 @@
 package org.commcare.dalvik.reminders.sync
 
 import android.content.Context
+import android.os.Build
+import androidx.annotation.RequiresApi
 import org.commcare.commcaresupportlibrary.CaseUtils
 import org.commcare.dalvik.reminders.model.Reminder
 
@@ -13,8 +15,11 @@ object CommCareUtils {
     private const val DETAIL = "detail"
     private const val TIME = "time"
     private const val SESSION_ENDPOINT = "session_endpoint"
+    // This case property will store a list of User IDs, separated by space or a coma, for whom
+    // the reminder should not be created
+    private const val USERS_TO_SKIP_REMINDER = "users_to_skip_reminder"
 
-    fun getRemindersFromCommCare(context : Context): ArrayList<Reminder> {
+    fun getRemindersFromCommCare(context: Context, currentUserId: String?): ArrayList<Reminder> {
         val remindersCaseCursor = CaseUtils.getCaseMetaData(
             context,
             "case_type = ? and status = 'open'",
@@ -28,6 +33,7 @@ object CommCareUtils {
                 props.add(TIME)
                 props.add(SESSION_ENDPOINT)
                 props.add(CASEID)
+                props.add(USERS_TO_SKIP_REMINDER)
                 val caseProperties = CaseUtils.getCaseProperties(
                     context,
                     remindersCaseCursor.getString(remindersCaseCursor.getColumnIndex(CASE_ID)),
@@ -38,7 +44,12 @@ object CommCareUtils {
                 val time = caseProperties[TIME]
                 val sessionEndpoint = caseProperties[SESSION_ENDPOINT] ?: ""
                 val caseId = caseProperties[CASEID] ?: ""
+                val usersToSkipReminder = caseProperties[USERS_TO_SKIP_REMINDER] ?: ""
 
+                if (currentUserId != null && usersToSkipReminder.isNotEmpty()
+                    && usersToSkipReminder.contains(currentUserId, true)){
+                    continue
+                }
                 if (time != null) {
                     val title = remindersCaseCursor.getString(remindersCaseCursor.getColumnIndex(CASE_NAME))
                     reminders.add(Reminder(0, title, detail, caseId, time, sessionEndpoint))

--- a/app/src/main/java/org/commcare/dalvik/reminders/sync/SyncCasesWorker.kt
+++ b/app/src/main/java/org/commcare/dalvik/reminders/sync/SyncCasesWorker.kt
@@ -3,14 +3,17 @@ package org.commcare.dalvik.reminders.sync
 import android.content.Context
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import org.commcare.dalvik.reminders.CommCareReceiver.Companion.CC_LOGGED_IN_USER_ID_KEY
 import org.commcare.dalvik.reminders.db.ReminderRepository
 import org.commcare.dalvik.reminders.db.ReminderRoomDatabase
 
-class SyncCasesWorker(appContext: Context, workerParams: WorkerParameters) : CoroutineWorker(appContext, workerParams) {
+class SyncCasesWorker(appContext: Context, private val workerParams: WorkerParameters) : CoroutineWorker(appContext, workerParams) {
 
     override suspend fun doWork(): Result {
+        val data = workerParams.inputData
+        val currentUserId = data.getString(CC_LOGGED_IN_USER_ID_KEY)
         val reminderDao = ReminderRoomDatabase.getDatabase(applicationContext).reminderDao()
-        ReminderRepository(reminderDao).refreshCasesFromCC(applicationContext)
+        ReminderRepository(reminderDao).refreshCasesFromCC(applicationContext, currentUserId)
         return Result.success()
     }
 }

--- a/app/src/main/java/org/commcare/dalvik/reminders/viewmodel/ReminderViewModel.kt
+++ b/app/src/main/java/org/commcare/dalvik/reminders/viewmodel/ReminderViewModel.kt
@@ -34,7 +34,7 @@ class ReminderViewModel(application: Application) : AndroidViewModel(application
     fun syncOnFirstRun() {
         if (PrefsUtil.isSyncPending(getApplication())) {
             viewModelScope.launch(Dispatchers.IO) {
-                repository.refreshCasesFromCC(getApplication())
+                repository.refreshCasesFromCC(getApplication(), null)
             }
         }
     }


### PR DESCRIPTION
This PR fixes an issue in which a CommCare user who have created a `commcare-reminder` case for another user also gets a reminder. The reason for this is that when CommCare sends the data update broadcast and the case purge is not yet complete, the Reminders app still picks up the `commcare-reminder` case and creates a reminder when it shouldn't. The fix is to basically prevent reminders from being created for the current logged in used, if the user is listed in a case property called `users_to_skip_reminder`.